### PR TITLE
Support secured connection to Elasticsearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 *.egg-info
 build
 dist
+*.iml
+
+# These are generated in sg_init.sh script
+tests/conf/node-0-keystore.jks
+tests/conf/truststore.jks

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ dist
 *.iml
 
 # These are generated in sg_init.sh script
-tests/conf/node-0-keystore.jks
+tests/conf/transport-node-0-keystore.jks
+tests/conf/http-node-0-keystore.jks
 tests/conf/truststore.jks

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,19 @@ jdk:
 
 env:
   # different connection classes to test
-#  - TEST_ES_CONNECTION=Urllib3HttpConnection ES_VERSION=2.4.1
-  - TEST_ES_CONNECTION=RequestsHttpConnection ES_VERSION=2.4.1
+  - TEST_ES_CONNECTION=Urllib3HttpConnection ES_VERSION=2.4.1 SG_VER=2.4.1.8 SG_SSL_VER=2.4.1.16 ES_CONF=./tests/conf ES_HOME=/tmp/elasticsearch TMP_DIR=/tmp
+#  - TEST_ES_CONNECTION=RequestsHttpConnection ES_VERSION=2.4.1 SG_VER=2.4.1.8 SG_SSL_VER=2.4.1.16 ES_CONF=./tests/conf ES_HOME=/tmp/elasticsearch TMP_DIR=/tmp
 
 install:
   - wget -O /tmp/es.zip "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=org.elasticsearch.distribution.zip&a=elasticsearch&e=zip&v=${ES_VERSION}"
-  - unzip /tmp/es.zip -d /tmp/
-  - mv /tmp/elasticsearch-${ES_VERSION} /tmp/elasticsearch
-#  - /tmp/elasticsearch/bin/elasticsearch -d -E script.inline=true -E path.repo=/tmp -E repositories.url.allowed_urls='http://*' -E node.attr.testattr=test
-  - /tmp/elasticsearch/bin/elasticsearch -d
-  - sleep 15
-#  - git clone https://github.com/elastic/elasticsearch.git ../elasticsearch
+  - unzip /tmp/es.zip -d ${TMP_DIR}
+  - mv /tmp/elasticsearch-${ES_VERSION} ${ES_HOME}
+  # Install and setup Elasticsearch & SearchGuard plugins
+  - chmod u+x ./tests/setup/sg_init.sh
+  - ./tests/setup/sg_init.sh
+  # Start ES
+#  - ${ES_HOME}/bin/elasticsearch -d -E script.inline=true -E path.repo=/tmp -E repositories.url.allowed_urls='http://*' -E node.attr.testattr=test
+#  - ${ES_HOME}/bin/elasticsearch -d --path.conf=$ES_CONF --security.manager.enabled=false
   - pip install -e .[test]
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ jdk:
 
 env:
   # different connection classes to test
-  - TEST_ES_CONNECTION=Urllib3HttpConnection ES_VERSION=2.4.1 SG_VER=2.4.1.8 SG_SSL_VER=2.4.1.16 ES_CONF=./tests/conf ES_HOME=/tmp/elasticsearch TMP_DIR=/tmp
-#  - TEST_ES_CONNECTION=RequestsHttpConnection ES_VERSION=2.4.1 SG_VER=2.4.1.8 SG_SSL_VER=2.4.1.16 ES_CONF=./tests/conf ES_HOME=/tmp/elasticsearch TMP_DIR=/tmp
+  - TEST_ES_CONNECTION=Urllib3HttpConnection ES_VER=2.4.1 SG_VER=2.4.1.8 SG_SSL_VER=2.4.1.16 ES_CONF=./tests/conf ES_HOME=/tmp/elasticsearch TMP_DIR=/tmp
+#  - TEST_ES_CONNECTION=RequestsHttpConnection ES_VER=2.4.1 SG_VER=2.4.1.8 SG_SSL_VER=2.4.1.16 ES_CONF=./tests/conf ES_HOME=/tmp/elasticsearch TMP_DIR=/tmp
 
 install:
-  - wget -O /tmp/es.zip "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=org.elasticsearch.distribution.zip&a=elasticsearch&e=zip&v=${ES_VERSION}"
+  - wget -O /tmp/es.zip "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=org.elasticsearch.distribution.zip&a=elasticsearch&e=zip&v=${ES_VER}"
   - unzip /tmp/es.zip -d ${TMP_DIR}
-  - mv /tmp/elasticsearch-${ES_VERSION} ${ES_HOME}
+  - mv /tmp/elasticsearch-${ES_VER} ${ES_HOME}
   # Install and setup Elasticsearch & SearchGuard plugins
   - chmod u+x ./tests/setup/sg_init.sh
   - ./tests/setup/sg_init.sh

--- a/README.rst
+++ b/README.rst
@@ -16,12 +16,12 @@ Synopsis
 The tool uses `docopt <http://docopt.org/>`_ to describe command line language and supports the following options::
 
     Usage:
-      watches cluster_health [-i=INTERVAL -d=DURATION --url=URL -tsv] [--level=LEVEL --local]
-      watches cluster_state  [-i=INTERVAL -d=DURATION --url=URL -tsv]
-      watches cluster_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv]
-      watches nodes_stats    [-i=INTERVAL -d=DURATION --url=URL -tsv]
-      watches nodes_info     [-i=INTERVAL -d=DURATION --url=URL -tsv] [--node_id=NODE_ID]
-      watches indices_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv] [--level=LEVEL --index=INDEX]
+      watches cluster_health [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [--level=LEVEL --local]
+      watches cluster_state  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)]
+      watches cluster_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)]
+      watches nodes_stats    [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)]
+      watches nodes_info     [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [--node_id=NODE_ID]
+      watches indices_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [--level=LEVEL --index=INDEX]
       watches -h
       watches --version
 
@@ -32,6 +32,9 @@ The tool uses `docopt <http://docopt.org/>`_ to describe command line language a
       -t, --timestamp     Add timestamp field to data. The value is local datetime converted to UTC in ISO 8601 format.
       -s, --sniff         Turn on sniffing.
       -v, --verbose       Print more debug info: input options, ... etc.
+      --cacert=CACERT     Path to Certification Authority Certificate pem file
+      --cert=CERT         Path to Client Certificate pem file
+      --key=KEY           Path to Client Key pem file
       --level=LEVEL       Aggregation level of returned data, valid options: cluster, indices or shards. [default: cluster].
       --local             Return the local node information instead of master node.
       --node_id=NODE_ID   A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from local node you're connecting to [default: ].
@@ -51,6 +54,13 @@ The tool uses `docopt <http://docopt.org/>`_ to describe command line language a
 
       # Alternatively, using short option notation
       $ watches cluster_health -i 1 -d 10 -s
+
+      # Get cluster health from secured node
+      $ watches cluster_health \
+          --url=https://localhots:9200 \
+          --cacert /tmp/search-guard-ssl/example-pki-scripts/ca/chain-ca.pem \
+          --cert /tmp/search-guard-ssl/example-pki-scripts/kirk.crt.pem \
+          --key /tmp/search-guard-ssl/example-pki-scripts/kirk.key.pem
 
 To connect to Elasticsearch cluster ``watches`` uses official
 `elasticsearch-py <https://github.com/elastic/elasticsearch-py/>`_ client which
@@ -73,7 +83,7 @@ some*), you would run the following command::
 This will trigger `py.test <http://pytest.org/latest/>`_, along with its popular
 `coverage <https://pypi.python.org/pypi/pytest-cov>`_ plugin.
 
-Tests assume ES node running on ``http://localhost:9200``.
+Read `Testing.md <./tests/Testing.md>`_ to learn more details.
 
 Lastly, if you'd like to cut a new release of this CLI tool, and publish it to
 the Python Package Index (`PyPI <https://pypi.python.org/pypi>`_), you can do so

--- a/tests/Testing.md
+++ b/tests/Testing.md
@@ -54,3 +54,34 @@ If you get correct response then this means you have successfully executed reque
 Now you can run all `watches` tests by calling:
 
     $ python setup.py test
+    
+## cURL with OpenSSL on MacOS
+
+If you are a MacOS user you might run into the following error when running cURL command
+with provided certs:
+
+    curl -vs 'https://localhost:9200/_cluster/health?pretty' \
+      --cacert /tmp/search-guard-ssl/example-pki-scripts/ca/chain-ca.pem \
+      --cert /tmp/search-guard-ssl/example-pki-scripts/kirk.crt.pem \
+      --key /tmp/search-guard-ssl/example-pki-scripts/kirk.key.pem
+    *   Trying ::1...
+    * Connected to localhost (::1) port 9200 (#0)
+    * WARNING: SSL: CURLOPT_SSLKEY is ignored by Secure Transport. The private key must be in the Keychain.
+    * WARNING: SSL: Certificate type not set, assuming PKCS#12 format.
+    * SSL: Can't load the certificate "/tmp/search-guard-ssl/example-pki-scripts/kirk.crt.pem" and its private key: OSStatus -25299
+    * Closing connection 0
+    
+In this case you are most likely running into [issue explained here](https://github.com/curl/curl/issues/283).
+One of the solutions is to switch cURL from using SecureTransport:
+
+    $ curl --version
+    curl 7.49.1 (x86_64-apple-darwin16.0) libcurl/7.49.1 SecureTransport zlib/1.2.8
+    Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp 
+    Features: AsynchDNS IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz UnixSockets
+    
+to use openSSL instead (follow [this tip](https://github.com/curl/curl/issues/283#issuecomment-243398486) to make it happen):
+ 
+    $ curl --version
+    curl 7.49.1 (x86_64-apple-darwin16.1.0) libcurl/7.49.1 OpenSSL/1.0.2h zlib/1.2.8
+    Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp 
+    Features: IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP UnixSockets

--- a/tests/Testing.md
+++ b/tests/Testing.md
@@ -1,0 +1,56 @@
+# How to run tests
+
+Tests are executed against **secured Elasticsearch cluster** running on `https://localhost:9200`.
+For securing Elasticsearch we use [Search Guard 2](https://github.com/floragunncom/search-guard/)
+plugins configured according to its tutorials. For the convenience we provide
+a simple script that can handle installation of SG plugins, generating required
+certificates, starting Elasticsearch search and configuring SG plugins as needed
+by tests (read below for details). 
+
+## Travis CI
+
+CI testing is all set up and running on Travis via [travis.yml](`../.travis.yml`)
+ and [sg_init.sh](setup/sg_init.sh) scripts automatically so you do not need
+ to worry about anything.
+ 
+## Testing manually
+
+Before you can execute tests you need to make sure that you can run Elasticsearch
+locally with all the needed security plugins. You can use
+provided [sg_init.sh](setup/sg_init.sh) script to configure Elasticsearch for the tests.
+
+Before you run this script make sure that:
+
+  - Elasticsearch of required version is installed on
+your machine
+  - Setup `ES_HOME` env variable and point it to home folder of Elasticsearch
+  - Elasticsearch is stopped and SG plugins **ARE NOT** installed
+  - Elasticsearch data folder (`path.data`) should be empty too 
+  
+For example, assume you want to use `Elasticsearch 2.4.1` for testing and it
+ is installed in folder `/home/elasticsearch-2.4.1`:
+ 
+    # Make sure ES_HOME is set correctly
+    export ES_HOME=/home/elasticsearch-2.4.1
+        
+    # First we clear all SG plugins, data and logs
+    $ cd $ES_HOME
+    $ rm -rf data/ plugins/ logs/
+    
+Then switch to `watches-cli` root folder and run init script:
+
+    $ cd <watches-cli.git.CLONE>_HOME
+    ./tests/setup/sg_init.sh
+    
+This script will install SG plugins, generate certificates, start Elasticsearch
+node and configure SG plugins as needed. When the script finishes you should be able
+to execute the following command:
+
+    curl -sS -u kirk:kirk 'https://localhost:9200/_cluster/health?pretty'
+    
+If you get correct response then this means you have successfully executed request to
+  secured Elasticsearch as an admin user called kirk.
+  
+Now you can run all `watches` tests by calling:
+
+    $ python setup.py test

--- a/tests/commands/secure_support.py
+++ b/tests/commands/secure_support.py
@@ -1,0 +1,33 @@
+
+
+from unittest import TestCase
+
+class TestSecureSupport(TestCase):
+    """
+    Support for tests running in secured context.
+    """
+
+    # Values compatible with setup script
+    _sec = {
+        '--url': 'https://localhost:9200',
+        '--cacert': '/tmp/search-guard-ssl/example-pki-scripts/ca/chain-ca.pem',
+        '--cert': '/tmp/search-guard-ssl/example-pki-scripts/kirk.crt.pem',
+        '--key': '/tmp/search-guard-ssl/example-pki-scripts/kirk.key.pem'
+    }
+
+    @staticmethod
+    def appendSecurityContext(list):
+
+        # In the future we can override with env variable
+        # import os
+        # security_enabled = os.environ["IS_ES_SECURED"]
+        security_enabled = True
+
+        if security_enabled:
+            list.append('--url=' + TestSecureSupport._sec['--url'])
+            list.append('--cacert=' + TestSecureSupport._sec['--cacert'])
+            list.append('--cert=' + TestSecureSupport._sec['--cert'])
+            list.append('--key=' + TestSecureSupport._sec['--key'])
+
+        # print "Secured command?", list
+        return list

--- a/tests/commands/test_cluster_health.py
+++ b/tests/commands/test_cluster_health.py
@@ -3,13 +3,14 @@
 
 import json
 from subprocess import PIPE, Popen as popen
-from unittest import TestCase
+from secure_support import TestSecureSupport
 from elasticsearch import Elasticsearch
 
 
-class TestClusterHealth(TestCase):
+class TestClusterHealth(TestSecureSupport):
     def test_returns_json(self):
-        output = popen(['watches', 'cluster_health'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'cluster_health'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue(len(o) == 15)
         self.assertTrue('status' in o)
@@ -18,7 +19,8 @@ class TestClusterHealth(TestCase):
 
 
     def test_returns_cluster_health_with_sniffing(self):
-        output = popen(['watches', 'cluster_health', '--sniff'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'cluster_health', '--sniff'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue(len(o) == 15)
         self.assertTrue('status' in o)
@@ -26,19 +28,22 @@ class TestClusterHealth(TestCase):
         self.assertTrue('number_of_nodes' in o)
 
     def test_returns_cluster_health_with_verbose(self):
-        output = popen(['watches', 'cluster_health', '--verbose'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'cluster_health', '--verbose'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         # Unless we index some data to cluster we can only check the indices field is present
         self.assertTrue('Supplied options' in output)
 
     def test_returns_cluster_health_with_timestamp(self):
-        output = popen(['watches', 'cluster_health', '--timestamp'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'cluster_health', '--timestamp'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         # Unless we index some data to cluster we can only check the indices field is present
         o = json.loads(output)
         self.assertTrue(len(o) == 16)
         self.assertTrue('timestamp' in o)
 
     def test_returns_cluster_health(self):
-        output = popen(['watches', 'cluster_health'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'cluster_health'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue('cluster_name' in o)
         self.assertTrue('number_of_nodes' in o)
@@ -54,7 +59,8 @@ class TestClusterHealth(TestCase):
         self.assertTrue('timestamp' not in o)
 
     def test_returns_cluster_health_with_indices(self):
-        output = popen(['watches', 'cluster_health', '--level=indices'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'cluster_health', '--level=indices'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue('indices' in o)
         self.assertTrue('shards' not in o)
@@ -66,7 +72,8 @@ class TestClusterHealth(TestCase):
         es = Elasticsearch()
         es.create(index='i', doc_type='t', id='1', body={}, ignore=409, refresh=True)
 
-        output = popen(['watches', 'cluster_health', '--level=shards'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'cluster_health', '--level=shards'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue('indices' in o)
         self.assertTrue('shards' in o['indices']['i'])

--- a/tests/commands/test_cluster_state.py
+++ b/tests/commands/test_cluster_state.py
@@ -3,17 +3,19 @@
 
 import json
 from subprocess import PIPE, Popen as popen
-from unittest import TestCase
+from secure_support import TestSecureSupport
 
 
-class TestClusterState(TestCase):
+class TestClusterState(TestSecureSupport):
     def test_returns_json(self):
-        output = popen(['watches', 'cluster_state'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'cluster_state'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue(len(o) == 9)
 
     def test_returns_cluster_state(self):
-        output = popen(['watches', 'cluster_state'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'cluster_state'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue('cluster_name' in o)
         self.assertTrue('state_uuid' in o)

--- a/tests/commands/test_cluster_stats.py
+++ b/tests/commands/test_cluster_stats.py
@@ -3,17 +3,19 @@
 
 import json
 from subprocess import PIPE, Popen as popen
-from unittest import TestCase
+from secure_support import TestSecureSupport
 
 
-class TestClusterStats(TestCase):
+class TestClusterStats(TestSecureSupport):
     def test_returns_multiple_lines(self):
-        output = popen(['watches', 'cluster_stats'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'cluster_stats'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue(len(o) == 5)
 
     def test_returns_cluster_stats(self):
-        output = popen(['watches', 'cluster_stats'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'cluster_stats'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue('cluster_name' in o)
         self.assertTrue('timestamp' in o)

--- a/tests/commands/test_indices_stats.py
+++ b/tests/commands/test_indices_stats.py
@@ -3,13 +3,14 @@
 
 import json
 from subprocess import PIPE, Popen as popen
-from unittest import TestCase
+from secure_support import TestSecureSupport
 from elasticsearch import Elasticsearch
 
 
-class TestIndicesStats(TestCase):
+class TestIndicesStats(TestSecureSupport):
     def test_returns_json(self):
-        output = popen(['watches', 'indices_stats'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'indices_stats'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue(len(o) == 2)
 
@@ -20,7 +21,8 @@ class TestIndicesStats(TestCase):
         es = Elasticsearch()
         es.create(index='i', doc_type='t', id='1', body={}, ignore=409, refresh=True)
 
-        output = popen(['watches', 'indices_stats',], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'indices_stats'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue(len(o) == 2)
         self.assertTrue('_all' in o)
@@ -33,7 +35,8 @@ class TestIndicesStats(TestCase):
         es = Elasticsearch()
         es.create(index='i', doc_type='t', id='1', body={}, ignore=409, refresh=True)
 
-        output = popen(['watches', 'indices_stats', '--level=shards'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'indices_stats', '--level=shards'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue(len(o) == 3)
         self.assertTrue('_all' in o)

--- a/tests/commands/test_nodes_info.py
+++ b/tests/commands/test_nodes_info.py
@@ -3,17 +3,19 @@
 
 import json
 from subprocess import PIPE, Popen as popen
-from unittest import TestCase
+from secure_support import TestSecureSupport
 
 
-class TestNodesInfo(TestCase):
+class TestNodesInfo(TestSecureSupport):
     def test_returns_json(self):
-        output = popen(['watches', 'nodes_info'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'nodes_info'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue(len(o) == 2)
 
     def test_returns_nodes_info(self):
-        output = popen(['watches', 'nodes_info'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'nodes_info'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue('cluster_name' in o)
         self.assertTrue('nodes' in o)

--- a/tests/commands/test_nodes_stats.py
+++ b/tests/commands/test_nodes_stats.py
@@ -2,17 +2,19 @@
 
 import json
 from subprocess import PIPE, Popen as popen
-from unittest import TestCase
+from secure_support import TestSecureSupport
 
 
-class TestNodesStats(TestCase):
+class TestNodesStats(TestSecureSupport):
     def test_returns_json(self):
-        output = popen(['watches', 'nodes_stats'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'nodes_stats'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue(len(o) == 2)
 
     def test_returns_cluster_stats(self):
-        output = popen(['watches', 'nodes_stats'], stdout=PIPE).communicate()[0]
+        cmd = self.appendSecurityContext(['watches', 'nodes_stats'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
         self.assertTrue('cluster_name' in o)
         self.assertTrue('nodes' in o)

--- a/tests/conf/elasticsearch.yml
+++ b/tests/conf/elasticsearch.yml
@@ -1,0 +1,38 @@
+cluster:
+  name: elasticsearch
+
+#path:
+#  data: /elasticsearch/persistent/${CLUSTER_NAME}/data
+#  logs: /elasticsearch/${CLUSTER_NAME}/logs
+#  work: /elasticsearch/${CLUSTER_NAME}/work
+#  scripts: /elasticsearch/${CLUSTER_NAME}/scripts
+
+searchguard:
+  authcz.admin_dn:
+#  - CN=system.admin,OU=OpenShift,O=Logging
+#  - cn=admin,ou=Test,ou=ou,dc=company,dc=com
+#  - cn=smith,ou=IT,ou=IT,dc=company,dc=com
+#kirk is admin
+  - CN=kirk, OU=client, O=client, L=Test, C=DE
+  config_index_name: "searchguard"
+  ssl:
+    transport:
+      enabled: true
+      enforce_hostname_verification: false
+      keystore_type: JKS
+      keystore_filepath: node-0-keystore.jks
+      keystore_password: changeit
+      truststore_type: JKS
+      truststore_filepath: truststore.jks
+      truststore_password: changeit
+      enable_openssl_if_available: false
+    http:
+      enabled: true
+      keystore_type: JKS
+      keystore_filepath: node-0-keystore.jks
+      keystore_password: changeit
+      clientauth_mode: OPTIONAL
+      truststore_type: JKS
+      truststore_filepath: truststore.jks
+      truststore_password: changeit
+      enable_openssl_if_available: false

--- a/tests/conf/elasticsearch.yml
+++ b/tests/conf/elasticsearch.yml
@@ -20,7 +20,7 @@ searchguard:
       enabled: true
       enforce_hostname_verification: false
       keystore_type: JKS
-      keystore_filepath: node-0-keystore.jks
+      keystore_filepath: transport-node-0-keystore.jks
       keystore_password: changeit
       truststore_type: JKS
       truststore_filepath: truststore.jks
@@ -29,7 +29,7 @@ searchguard:
     http:
       enabled: true
       keystore_type: JKS
-      keystore_filepath: node-0-keystore.jks
+      keystore_filepath: http-node-0-keystore.jks
       keystore_password: changeit
       clientauth_mode: OPTIONAL
       truststore_type: JKS

--- a/tests/conf/logging.yml
+++ b/tests/conf/logging.yml
@@ -1,0 +1,71 @@
+# you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+es.logger.level: INFO
+rootLogger: ${es.logger.level}, console, file
+logger:
+  # log action execution errors for easier debugging
+  action: DEBUG
+
+  # deprecation logging, turn to DEBUG to see them
+  deprecation: INFO, deprecation_log_file
+
+  org.apache.http: INFO
+
+  # gateway
+  #gateway: DEBUG
+  #index.gateway: DEBUG
+
+  # peer shard recovery
+  #indices.recovery: DEBUG
+
+  # discovery
+  #discovery: TRACE
+
+  # search-guard
+  com.floragunn.searchguard: WARN
+
+  index.search.slowlog: TRACE, index_search_slow_log_file
+  index.indexing.slowlog: TRACE, index_indexing_slow_log_file
+
+additivity:
+  index.search.slowlog: false
+  index.indexing.slowlog: false
+  deprecation: false
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %.10000m%n"
+
+  deprecation_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}_deprecation.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  index_search_slow_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}_index_search_slowlog.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  index_indexing_slow_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}_index_indexing_slowlog.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"

--- a/tests/setup/sg_init.sh
+++ b/tests/setup/sg_init.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -ex
+
+# ----------------------------------------------
+# This script installs Search Guard plugins, starts Elasticsearch and finishes
+# initialization of Search Guard plugin. It needs to be executed only once. You
+# can then shutdown Elasticsearch and start it again and all will be set as needed.
+#
+# The following env variables are set to enable smooth testing in Travis, you might
+# want to tweak them accordingly if testing locally.
+# ----------------------------------------------
+
+export ES_VERSION=${ES_VERSION:-2.4.1}
+export SG_VER=${SG_VER:-2.4.1.8}
+export SG_SSL_VER=${SG_SSL_VER:-2.4.1.16}
+export TMP_DIR=${TMP_DIR:-/tmp}
+export ES_HOME=${ES_HOME:-$TMP_DIR/elasticsearch}
+export ES_CONF=${ES_CONF:-./tests/conf}
+
+
+# ----------------------------------------------
+# Install SSL plugin
+# See: <https://github.com/floragunncom/search-guard-ssl-docs/blob/master/installation.md>
+
+[[ -d ${ES_HOME}/bin/plugin/search-guard-ssl ]] && rm -rf ${ES_HOME}/bin/plugin/search-guard-ssl
+${ES_HOME}/bin/plugin install -b com.floragunn/search-guard-ssl/${SG_SSL_VER}
+
+# ----------------------------------------------
+# Follow Quickstart tutorial
+# See: <https://github.com/floragunncom/search-guard-ssl-docs/blob/master/quickstart.md>
+# Use PKI scripts: <https://github.com/floragunncom/search-guard-ssl-docs/blob/master/quickstart.md#using-the-example-pki-scripts>
+
+ACTUAL_DIR=`pwd`
+[[ -d ${TMP_DIR} ]] || mkdir ${TMP_DIR}
+cd ${TMP_DIR}
+[[ -d ${TMP_DIR}/search-guard-ssl ]] && rm -rf ${TMP_DIR}/search-guard-ssl
+git clone https://github.com/floragunncom/search-guard-ssl.git
+cd search-guard-ssl
+git checkout v${SG_SSL_VER}
+cd example-pki-scripts/
+./example.sh
+cd ${ACTUAL_DIR}
+
+cp ${TMP_DIR}/search-guard-ssl/example-pki-scripts/truststore.jks ${ES_CONF}
+cp ${TMP_DIR}/search-guard-ssl/example-pki-scripts/node-0-keystore.jks ${ES_CONF}
+
+# ----------------------------------------------
+# Install Search Guard plugin
+# See: <https://github.com/floragunncom/search-guard/#installation>
+
+[[ -d ${ES_HOME}/bin/plugin/search-guard-2 ]] && rm -rf ${ES_HOME}/bin/plugin/search-guard-2
+${ES_HOME}/bin/plugin install -b com.floragunn/search-guard-2/${SG_VER}
+
+# ----------------------------------------------
+# Start elasticsearch
+${ES_HOME}/bin/elasticsearch -d --security.manager.enabled=false --path.conf=./tests/conf/
+sleep 15
+tail ${ES_HOME}/logs/elasticsearch.log
+
+# ----------------------------------------------
+# Make sure sgadmin tool is executable
+cd ${ES_HOME}/plugins/search-guard-2/tools
+chmod u+x *.sh
+cp ${TMP_DIR}/search-guard-ssl/example-pki-scripts/node-0-keystore.jks ${ES_HOME}/plugins/search-guard-2/sgconfig
+cp ${TMP_DIR}/search-guard-ssl/example-pki-scripts/truststore.jks ${ES_HOME}/plugins/search-guard-2/sgconfig
+
+cd ${ES_HOME}
+plugins/search-guard-2/tools/sgadmin.sh \
+  -cd plugins/search-guard-2/sgconfig/ \
+  -ks plugins/search-guard-2/sgconfig/node-0-keystore.jks \
+  -ts plugins/search-guard-2/sgconfig/truststore.jks \
+  -nhnv
+
+# plugins/search-guard-2/tools/hash.sh -p mycleartextpassword
+
+cd ${ACTUAL_DIR}
+
+# ----------------------------------------------
+# Make some curl requests to ES node.
+# See: <https://github.com/floragunncom/search-guard/blob/master/demo/searchguard_init.sh>
+
+# User kirk is an admin.
+curl -sS --insecure -u kirk:kirk 'https://localhost:9200/'
+curl -sS --insecure -u kirk:kirk 'https://localhost:9200/_searchguard/sslinfo?pretty'
+curl -sS --insecure -u kirk:kirk 'https://localhost:9200/_cluster/health?pretty'
+
+curl -vs -u kirk:kirk 'https://localhost:9200/_cluster/health?pretty' \
+  --cacert ${TMP_DIR}/search-guard-ssl/example-pki-scripts/ca/chain-ca.pem
+
+curl -vs 'https://localhost:9200/_cluster/health?pretty' \
+  --cacert ${TMP_DIR}/search-guard-ssl/example-pki-scripts/ca/chain-ca.pem \
+  --cert ${TMP_DIR}/search-guard-ssl/example-pki-scripts/kirk.crt.pem \
+  --key  ${TMP_DIR}/search-guard-ssl/example-pki-scripts/kirk.key.pem
+
+# User spock is NOT an admin
+curl -sS --insecure -u kirk:kirk 'https://localhost:9200/'
+# This request should be rejected (403)
+curl -sS --insecure -u spock:spock 'https://localhost:9200/_cluster/health?pretty'

--- a/tests/setup/sg_init.sh
+++ b/tests/setup/sg_init.sh
@@ -66,8 +66,9 @@ ${ES_HOME}/bin/plugin install -b com.floragunn/search-guard-2/${SG_VER}
 cd ${ES_HOME}/plugins/search-guard-2/tools
 chmod u+x *.sh
 # sgadmin.sh uses the inter-node transport, not http
-cp ${TMP_DIR}/search-guard-ssl/example-pki-scripts/transport/node-0-keystore.jks ${ES_HOME}/plugins/search-guard-2/sgconfig
-cp ${TMP_DIR}/search-guard-ssl/example-pki-scripts/truststore.jks ${ES_HOME}/plugins/search-guard-2/sgconfig
+cp ${TMP_DIR}/search-guard-ssl/example-pki-scripts/truststore.jks ${ES_HOME}/plugins/search-guard-2/sgconfig/truststore.jks
+cp ${TMP_DIR}/search-guard-ssl/example-pki-scripts/transport/node-0-keystore.jks ${ES_HOME}/plugins/search-guard-2/sgconfig/transport-node-0-keystore.jks
+cd ${ACTUAL_DIR}
 
 if [ "${SG_SETUP_ONLY:-}" = true ] ; then
     exit 0
@@ -82,7 +83,7 @@ tail ${ES_HOME}/logs/elasticsearch.log
 cd ${ES_HOME}
 plugins/search-guard-2/tools/sgadmin.sh \
   -cd plugins/search-guard-2/sgconfig/ \
-  -ks plugins/search-guard-2/sgconfig/node-0-keystore.jks \
+  -ks plugins/search-guard-2/sgconfig/transport-node-0-keystore.jks \
   -ts plugins/search-guard-2/sgconfig/truststore.jks \
   -nhnv
 
@@ -109,5 +110,5 @@ curl -vs 'https://localhost:9200/_cluster/health?pretty' \
 
 # User spock is NOT an admin
 curl -sS --insecure -u kirk:kirk 'https://localhost:9200/'
-# This request should be rejected (403)
+echo This request should be rejected \(403\)
 curl -sS --insecure -u spock:spock 'https://localhost:9200/_cluster/health?pretty'

--- a/watches/cli.py
+++ b/watches/cli.py
@@ -2,12 +2,12 @@
 watches
 
 Usage:
-  watches cluster_health [-i=INTERVAL -d=DURATION --url=URL -tsv] [--level=LEVEL --local]
-  watches cluster_state  [-i=INTERVAL -d=DURATION --url=URL -tsv]
-  watches cluster_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv]
-  watches nodes_stats    [-i=INTERVAL -d=DURATION --url=URL -tsv]
-  watches nodes_info     [-i=INTERVAL -d=DURATION --url=URL -tsv] [--node_id=NODE_ID]
-  watches indices_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv] [--level=LEVEL --index=INDEX]
+  watches cluster_health [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [--level=LEVEL --local]
+  watches cluster_state  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)]
+  watches cluster_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)]
+  watches nodes_stats    [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)]
+  watches nodes_info     [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [--node_id=NODE_ID]
+  watches indices_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [--level=LEVEL --index=INDEX]
   watches -h
   watches --version
 
@@ -18,6 +18,9 @@ Options:
   -t, --timestamp     Add timestamp field to data. The value is local datetime converted to UTC in ISO 8601 format.
   -s, --sniff         Turn on sniffing.
   -v, --verbose       Print more debug info: input options, ... etc.
+  --cacert=CACERT     Path to Certification Authority Certificate pem file
+  --cert=CERT         Path to Client Certificate pem file
+  --key=KEY           Path to Client Key pem file
   --level=LEVEL       Aggregation level of returned data, valid options: cluster, indices or shards. [default: cluster].
   --local             Return the local node information instead of master node.
   --node_id=NODE_ID   A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from local node you're connecting to [default: ].
@@ -37,6 +40,13 @@ Examples:
 
   # Alternatively, using short option notation
   $ watches cluster_health -i 1 -d 10 -s
+
+  # Get cluster health from secured node
+  $ watches cluster_health \
+      --url=https://localhots:9200 \
+      --cacert /tmp/search-guard-ssl/example-pki-scripts/ca/chain-ca.pem \
+      --cert /tmp/search-guard-ssl/example-pki-scripts/kirk.crt.pem \
+      --key /tmp/search-guard-ssl/example-pki-scripts/kirk.key.pem
 
 Help:
   For help using this tool, please open an issue on the GitHub repository:

--- a/watches/commands/base.py
+++ b/watches/commands/base.py
@@ -17,16 +17,26 @@ class Base(object):
         if self.options["--verbose"]:
             print 'Supplied options:', dumps(self.options, indent=2, sort_keys=True)
 
+        user_kwargs = {}
+
+        user_kwargs["hosts"] = options["--url"]
+
         if self.options["--sniff"]:
-            self.es = Elasticsearch([options["--url"]],
-                # sniff before doing anything
-                sniff_on_start=True,
-                # refresh nodes after a node fails to respond
-                sniff_on_connection_fail=True,
-                # and also every 60 seconds
-                sniffer_timeout=60 )
-        else:
-            self.es = Elasticsearch([options["--url"]])
+            # sniff before doing anything
+            user_kwargs["sniff_on_start"] = True
+            # refresh nodes after a node fails to respond
+            user_kwargs["sniff_on_connection_fail"] = True
+            # and also every 60 seconds
+            user_kwargs["sniffer_timeout"] = 60
+
+        # We can test just for --cacert because all the three options are required
+        # if at least one of them is provided.
+        if self.options["--cacert"]:
+            user_kwargs["ca_certs"] = options["--cacert"]
+            user_kwargs["client_cert"] = options["--cert"]
+            user_kwargs["client_key"] = options["--key"]
+
+        self.es = Elasticsearch(**user_kwargs)
 
     def run(self):
         # Not sure if this is the best way to convert localtime to UTC in ISO 8601 format


### PR DESCRIPTION
- Add script to install & configure SG plugins
- Add new options to pass in certificates
- Add relevant documentation
- Closes #1 
- Closes #3 

A few tests are still failing but this is not related to security, see #2 for details.