### PR TITLE
Support for more security options #6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jdk:
 
 env:
   # different connection classes to test
-  - TEST_ES_CONNECTION=Urllib3HttpConnection ES_VER=2.4.1 SG_VER=2.4.1.8 SG_SSL_VER=2.4.1.16 ES_CONF=./tests/conf ES_HOME=/tmp/elasticsearch TMP_DIR=/tmp
+  - TEST_ES_CONNECTION=Urllib3HttpConnection ES_VER=2.4.2 SG_VER=2.4.2.9 SG_SSL_VER=2.4.2.19 ES_CONF=./tests/conf ES_HOME=/tmp/elasticsearch TMP_DIR=/tmp
 #  - TEST_ES_CONNECTION=RequestsHttpConnection ES_VER=2.4.1 SG_VER=2.4.1.8 SG_SSL_VER=2.4.1.16 ES_CONF=./tests/conf ES_HOME=/tmp/elasticsearch TMP_DIR=/tmp
 
 install:

--- a/tests/commands/secure_support.py
+++ b/tests/commands/secure_support.py
@@ -33,6 +33,21 @@ class TestSecureSupport(TestCase):
         return list
 
     @staticmethod
+    def appendOnlyCAcert(list):
+
+        # In the future we can override with env variable
+        # import os
+        # security_enabled = os.environ["IS_ES_SECURED"]
+        security_enabled = True
+
+        if security_enabled:
+            list.append('--url=' + TestSecureSupport._sec['--url'])
+            list.append('--cacert=' + TestSecureSupport._sec['--cacert'])
+
+        # print "Secured command?", list
+        return list
+
+    @staticmethod
     def options_from_list(list):
         # for i in list:
         #     item = i.split('=')

--- a/tests/setup/setup_run_all.sh
+++ b/tests/setup/setup_run_all.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euxo pipefail
+
+type -t virtualenv || { echo please install /usr/bin/virtualenv ; exit 1 ; }
+type -t pip || { echo please install /usr/bin/pip ; exit 1 ; }
+type -t wget || { echo please install /usr/bin/wget ; exit 1 ; }
+type -t unzip || { echo please install /usr/bin/unzip ; exit 1 ; }
+
+# different connection classes to test
+#TEST_ES_CONNECTION=${TEST_ES_CONNECTION:-RequestsHttpConnection}
+export TEST_ES_CONNECTION=${TEST_ES_CONNECTION:-Urllib3HttpConnection}
+export ES_VER=${ES_VER:-2.4.2}
+export SG_VER=${SG_VER:-2.4.2.9}
+export SG_SSL_VER=${SG_SSL_VER:-2.4.2.19}
+export ES_CONF=${ES_CONF:-./tests/conf}
+export ES_HOME=${ES_HOME:-/tmp/elasticsearch}
+export TMP_DIR=${TMP_DIR:-/tmp}
+
+if [ ! -f /tmp/es.zip ] ; then
+    wget -O /tmp/es.zip "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=org.elasticsearch.distribution.zip&a=elasticsearch&e=zip&v=${ES_VER}"
+fi
+
+if [ ! -d $ES_HOME ] ; then
+    unzip /tmp/es.zip -d ${TMP_DIR}
+    mv /tmp/elasticsearch-${ES_VER} ${ES_HOME}
+fi
+
+rm -rf $ES_HOME/{data,plugins,logs}
+./tests/setup/sg_init.sh
+
+virtualenv -q .venv
+PS1=
+. .venv/bin/activate
+pip install -e .[test]
+
+python setup.py test

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 """Tests for our main watches CLI module."""
 
-
 from subprocess import PIPE, Popen as popen
 from unittest import TestCase
 

--- a/watches/cli.py
+++ b/watches/cli.py
@@ -2,12 +2,12 @@
 watches
 
 Usage:
-  watches cluster_health [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [-f=FILTER...] [--level=LEVEL --local]
-  watches cluster_state  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [-f=FILTER...] [--local --index=INDEX --metric=METRIC]
-  watches cluster_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [-f=FILTER...]
-  watches nodes_stats    [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [-f=FILTER...] [--metric=METRIC]
-  watches nodes_info     [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [-f=FILTER...] [--node_id=NODE_ID --metric=METRIC]
-  watches indices_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY)] [-f=FILTER...] [--level=LEVEL --index=INDEX]
+  watches cluster_health [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [-f=FILTER...] [--level=LEVEL --local] [--header=HEADER...]
+  watches cluster_state  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [-f=FILTER...] [--local --index=INDEX --metric=METRIC] [--header=HEADER...]
+  watches cluster_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [-f=FILTER...] [--header=HEADER...]
+  watches nodes_stats    [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [-f=FILTER...] [--metric=METRIC] [--header=HEADER...]
+  watches nodes_info     [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [-f=FILTER...] [--node_id=NODE_ID --metric=METRIC] [--header=HEADER...]
+  watches indices_stats  [-i=INTERVAL -d=DURATION --url=URL -tsv] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [-f=FILTER...] [--level=LEVEL --index=INDEX] [--header=HEADER...]
   watches -h
   watches --version
 
@@ -19,6 +19,8 @@ Options:
   -s, --sniff         Turn on sniffing.
   -v, --verbose       Print more debug info: input options, ... etc.
   -f=FILTER, --filter_path=FILTER   Filter returned JSON (see http://elasticsearch-py.readthedocs.io/en/master/api.html#response-filtering)
+  --username=USERNAME Username to authenticate with
+  --password=PASSWORD Password to authenticate with
   --cacert=CACERT     Path to Certification Authority Certificate pem file
   --cert=CERT         Path to Client Certificate pem file
   --key=KEY           Path to Client Key pem file
@@ -29,6 +31,7 @@ Options:
   --metric=METRIC     A comma-separated list of metric names; use `_all` or empty string to perform the operation for all metrics.
   -h, --help          Show this screen.
   --version           Show version.
+  --header=HEADER     Custom HTTP header to add to the request (e.g. --header="X-Proxy-Remote-User: username")
 
 Examples:
   # Get cluster health from specified HTTP endpoint with added "timestamp" field in the response

--- a/watches/util/ESClientProducer.py
+++ b/watches/util/ESClientProducer.py
@@ -12,6 +12,11 @@ def create_client(options):
             'hosts': options["--url"]
         })
 
+    if "--username" in options or "--password" in options:
+        http_auth_str = "://{}:{}@".format(options["--username"], options["--password"])
+        url = user_kwargs.get('hosts', 'http://localhost:9200')
+        user_kwargs['hosts'] = url.replace('://', http_auth_str)
+
     # "true" is not translated to native True value ?
     if "--sniff" in options and "true" == options["--sniff"]:
         user_kwargs.update({
@@ -23,13 +28,33 @@ def create_client(options):
             "sniffer_timeout": 60
         })
 
-    # We can test just for --cacert because all the three options are required
-    # if at least one of them is provided.
-    if "--cacert" in options and options["--cacert"] is not None and len(options["--cacert"]) > 0:
+    if "--cacert" in options and options['--cacert']:
+        #see if the value is a string or a list
+        if isinstance(options['--cacert'], basestring):
+            cacert = options['--cacert']
+        else: # assume list
+            cacert = options['--cacert'][0]
+        # because we mention --cacert in two places in the docopt, it automatically
+        # converts to a list - we just take the first one
         user_kwargs.update({
-            "ca_certs": options["--cacert"],
+            "ca_certs": cacert
+        })
+
+    # if --cert or --key is provided, both must be provided, and --cacert too
+    if "--cert" in options or "--key" in options:
+        user_kwargs.update({
             "client_cert": options["--cert"],
             "client_key": options["--key"]
+        })
+
+    # convert from list to dict
+    headers = {}
+    for hdr in options.get('--header', []):
+        k,v = hdr.split(':', 1)
+        headers[k] = v.lstrip()
+    if headers:
+         user_kwargs.update({
+            "headers": headers
         })
 
     es = Elasticsearch(**user_kwargs)


### PR DESCRIPTION
https://github.com/ViaQ/watches-cli/issues/6

Allow using `--cacert` without `--cert` and `--key`.  This still requires
that all 3 must be specified to use client cert auth, but allows the use
of `--cacert` by itself in order to use other forms of auth.

Allow specifying HTTP headers.  For example, to authenticate to OpenShift
Elasticsearch, after exposing it via a reencrypt route, you use curl like
this:

    curl -s --cacert ca.crt -H "X-Proxy-Remote-User: esuser" \
        -H "Authorization: Bearer asjasodfiasdjf" \
        -H "X-Forwarded-For: 127.0.0.1" \
        https://es.test/_cluster/health

With watches-cli, this becomes:

    watches cluster_health --cacert ca.crt \
        --header "X-Proxy-Remote-User: esuser" \
        --header "Authorization: Bearer asjasodfiasdjf" \
        --header "X-Forwarded-For: 127.0.0.1" \
        --url https://es.test/_cluster/health

There is no support for `--username/--password` yet.