### PR TITLE
Add option to transform JSON response

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,12 +15,12 @@ Synopsis
 The tool uses `docopt <http://docopt.org/>`_ to describe command line language and supports the following options::
 
     Usage:
-      watches cluster_health   [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--level=LEVEL --local]
-      watches cluster_state    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--local --index=INDEX --metric=METRIC]
-      watches cluster_stats    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...]
-      watches nodes_stats      [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--metric=METRIC]
-      watches nodes_info       [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--node_id=NODE_ID --metric=METRIC]
-      watches indices_stats    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--level=LEVEL --index=INDEX]
+      watches cluster_health   [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE] [--level=LEVEL --local]
+      watches cluster_state    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE] [--local --index=INDEX --metric=METRIC]
+      watches cluster_stats    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE]
+      watches nodes_stats      [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE] [--metric=METRIC]
+      watches nodes_info       [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE] [--node_id=NODE_ID --metric=METRIC]
+      watches indices_stats    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE] [--level=LEVEL --index=INDEX]
       watches nodes_hotthreads [-i=INTERVAL -d=DURATION --url=URL -bsv] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--node_id=NODE_ID --threads=THREADS --delay=DELAY --type=TYPE]
       watches -h
       watches --version
@@ -48,6 +48,7 @@ The tool uses `docopt <http://docopt.org/>`_ to describe command line language a
       --threads=THREADS   Specify the number of threads to provide information for.
       --delay=DELAY       Delay (interval) to do the second sampling of threads.
       --type=TYPE         The type of threads to sample (default: cpu), valid choices are: 'cpu', 'wait', 'block'.
+      --transform=TYPE    Transform JSON response (see online doc for more details). Valid choices: 'nested'.
       -h, --help          Show this screen.
       --version           Show version.
       --header=HEADER     Custom HTTP header to add to the request (e.g. --header="X-Proxy-Remote-User: username")

--- a/tests/commands/test_cluster_state.py
+++ b/tests/commands/test_cluster_state.py
@@ -60,3 +60,66 @@ class TestClusterState(TestSecureSupport):
         self.assertTrue(len(o) == 2)
         self.assertTrue('cluster_name' in o)
         self.assertTrue('master_node' in o)
+
+    def test_returns_cluster_state_nested(self):
+        cmd = self.appendSecurityCommands(['watches', 'cluster_state', '--transform=nested'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
+        o = json.loads(output)
+
+        self.assertTrue('metadata' in o)
+        self.assertTrue('indices' in o['metadata'])
+        indices = o['metadata']['indices']
+
+        # Indices is an array
+        self.assertTrue(isinstance(indices, list))
+        self.assertTrue(len(indices) > 0)
+
+        for index in indices:
+            # Each item in indices array must be dictionary
+            self.assertTrue(isinstance(index, dict))
+
+            # Each item must contain 'index' field which is expected to hold index name (thus string type)
+            self.assertTrue('index' in index)
+            self.assertTrue(isinstance(index['index'], basestring))
+
+        # Nodes is an array
+        self.assertTrue('nodes' in o)
+        nodes = o['nodes']
+        self.assertTrue(isinstance(nodes, list))
+        self.assertTrue(len(nodes) > 0)
+
+        for node in nodes:
+            # Each item in nodes array must be dictionary
+            self.assertTrue(isinstance(node, dict))
+            # Each item must contain 'node' field which is expected to hold node hash id (thus string type)
+            self.assertTrue('node' in node)
+            self.assertTrue(isinstance(node['node'], basestring))
+
+        # Routing table indices
+        self.assertTrue('routing_table' in o)
+        self.assertTrue('indices' in o['routing_table'])
+        indices = o['routing_table']['indices']
+        self.assertTrue(isinstance(indices, list))
+        self.assertTrue(len(indices) > 0)
+        for index in indices:
+            self.assertTrue(isinstance(index, dict))
+            self.assertTrue('index' in index)
+            self.assertTrue(isinstance(index['index'], basestring))
+            self.assertTrue('shards' in index)
+            self.assertTrue(isinstance(index['shards'], list))
+            self.assertTrue(len(index['shards']) > 0)
+            for shard in index['shards']:
+                self.assertTrue(isinstance(shard, dict))
+                self.assertTrue('shard' in shard)
+                self.assertTrue(isinstance(shard['shard'], int))
+
+        # Routing nodes nodes
+        self.assertTrue('routing_nodes' in o)
+        self.assertTrue('nodes' in o['routing_nodes'])
+        nodes = o['routing_nodes']['nodes']
+        self.assertTrue(isinstance(nodes, list))
+        self.assertTrue(len(nodes) > 0)
+        for node in nodes:
+            self.assertTrue('node' in node)
+            self.assertTrue('shard' in node)
+            self.assertTrue('index' in node)

--- a/tests/commands/test_indices_stats.py
+++ b/tests/commands/test_indices_stats.py
@@ -61,3 +61,29 @@ class TestIndicesStats(TestSecureSupport):
         self.assertTrue(len(docs) == 2)
         self.assertTrue('count' in docs)
         self.assertTrue('deleted' in docs)
+
+    def test_returns_nodes_info_shards_nested(self):
+        cmd = self.appendSecurityCommands(['watches', 'indices_stats', '--index=i', '--level=shards', '--transform=nested'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
+        o = json.loads(output)
+
+        # Indices is an array
+        self.assertTrue('indices' in o)
+        indices = o['indices']
+        self.assertTrue(isinstance(indices, list))
+        self.assertTrue(len(indices) > 0)
+
+        for index in indices:
+            # Each item in indices array must be dictionary
+            self.assertTrue(isinstance(index, dict))
+            # Each item must contain 'index' field which is expected to hold index name (thus string type)
+            self.assertTrue('index' in index)
+            self.assertTrue(isinstance(index['index'], basestring))
+
+            self.assertTrue('shards' in index)
+            self.assertTrue(isinstance(index['shards'], list))
+            self.assertTrue(len(index['shards']) > 0)
+
+            for shard in index['shards']:
+                self.assertTrue('shard' in shard)
+                self.assertTrue(isinstance(shard['shard'], int))

--- a/tests/commands/test_nodes_info.py
+++ b/tests/commands/test_nodes_info.py
@@ -34,7 +34,7 @@ class TestNodesInfo(TestSecureSupport):
         cmd = self.appendSecurityCommands(['watches', 'nodes_info', '--metric=http,process'])
         output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
-        self.assertTrue(len(o['nodes']) == 1)
+        self.assertTrue(len(o['nodes']) > 0)
         node_id = o['nodes'].keys()[0]
         node_info = o['nodes'][node_id]
         # We required two metrics, but there is some other info available in any case,
@@ -62,3 +62,20 @@ class TestNodesInfo(TestSecureSupport):
         self.assertTrue('max' in bulk)
         self.assertTrue('type' in bulk)
         self.assertTrue('queue_size' in bulk)
+
+    def test_returns_nodes_info_nested(self):
+        cmd = self.appendSecurityCommands(['watches', 'nodes_info', '--transform=nested'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
+        o = json.loads(output)
+
+        self.assertTrue('nodes' in o)
+        nodes = o['nodes']
+        self.assertTrue(isinstance(nodes, list))
+        self.assertTrue(len(nodes) > 0)
+
+        for node in nodes:
+            # Each item in nodes array must be dictionary
+            self.assertTrue(isinstance(node, dict))
+            # Each item must contain 'node' field which is expected to hold node hash id (thus string type)
+            self.assertTrue('node' in node)
+            self.assertTrue(isinstance(node['node'], basestring))

--- a/tests/commands/test_nodes_stats.py
+++ b/tests/commands/test_nodes_stats.py
@@ -32,7 +32,7 @@ class TestNodesStats(TestSecureSupport):
         cmd = self.appendSecurityCommands(['watches', 'nodes_stats', '--metric=transport,os'])
         output = popen(cmd, stdout=PIPE).communicate()[0]
         o = json.loads(output)
-        self.assertTrue(len(o['nodes']) == 1)
+        self.assertTrue(len(o['nodes']) > 0)
         node_id = o['nodes'].keys()[0]
         node_stats = o['nodes'][node_id]
         # We required two metrics, but there is some other info available in any case,
@@ -60,3 +60,20 @@ class TestNodesStats(TestSecureSupport):
         self.assertTrue('threads' in bulk)
         self.assertTrue('largest' in bulk)
         self.assertTrue('active' in bulk)
+
+    def test_returns_cluster_stats_nested(self):
+        cmd = self.appendSecurityCommands(['watches', 'nodes_stats', '--transform=nested'])
+        output = popen(cmd, stdout=PIPE).communicate()[0]
+        o = json.loads(output)
+
+        self.assertTrue('nodes' in o)
+        nodes = o['nodes']
+        self.assertTrue(isinstance(nodes, list))
+        self.assertTrue(len(nodes) > 0)
+
+        for node in nodes:
+            # Each item in nodes array must be dictionary
+            self.assertTrue(isinstance(node, dict))
+            # Each item must contain 'node' field which is expected to hold node hash id (thus string type)
+            self.assertTrue('node' in node)
+            self.assertTrue(isinstance(node['node'], basestring))

--- a/watches/cli.py
+++ b/watches/cli.py
@@ -2,12 +2,12 @@
 watches
 
 Usage:
-  watches cluster_health   [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--level=LEVEL --local]
-  watches cluster_state    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--local --index=INDEX --metric=METRIC]
-  watches cluster_stats    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...]
-  watches nodes_stats      [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--metric=METRIC]
-  watches nodes_info       [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--node_id=NODE_ID --metric=METRIC]
-  watches indices_stats    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--level=LEVEL --index=INDEX]
+  watches cluster_health   [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE] [--level=LEVEL --local]
+  watches cluster_state    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE] [--local --index=INDEX --metric=METRIC]
+  watches cluster_stats    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE]
+  watches nodes_stats      [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE] [--metric=METRIC]
+  watches nodes_info       [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE] [--node_id=NODE_ID --metric=METRIC]
+  watches indices_stats    [-i=INTERVAL -d=DURATION --url=URL -bltsv -f=FILTER...] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--transform=TYPE] [--level=LEVEL --index=INDEX]
   watches nodes_hotthreads [-i=INTERVAL -d=DURATION --url=URL -bsv] [(--cacert=CACERT --cert=CERT --key=KEY) | (--cacert=CACERT)] [(--username=USERNAME --password=PASSWORD)] [--header=HEADER...] [--node_id=NODE_ID --threads=THREADS --delay=DELAY --type=TYPE]
   watches -h
   watches --version
@@ -35,6 +35,7 @@ Options:
   --threads=THREADS   Specify the number of threads to provide information for.
   --delay=DELAY       Delay (interval) to do the second sampling of threads.
   --type=TYPE         The type of threads to sample (default: cpu), valid choices are: 'cpu', 'wait', 'block'.
+  --transform=TYPE    Transform JSON response (see online doc for more details). Valid choices: 'nested'.
   -h, --help          Show this screen.
   --version           Show version.
   --header=HEADER     Custom HTTP header to add to the request (e.g. --header="X-Proxy-Remote-User: username")

--- a/watches/commands/base.py
+++ b/watches/commands/base.py
@@ -30,8 +30,13 @@ class Base(object):
 
         # Treat JSON_APPLICATION response differently than TEXT_PLAIN
         if self.JSON_APPLICATION == self.getResponseContentType():
+
             if self.options["--timestamp"]:
                 data['timestamp'] = ts
+
+            if self.options["--transform"]:
+                data = self.transformData(data)
+
             if self.options["-l"]:
                 print dumps(data, default=lambda x:str(x))
             else:
@@ -45,6 +50,145 @@ class Base(object):
     def getResponseContentType(self):
         """Response MIME type. By default we assume JSON, make sure to override if needed."""
         return self.JSON_APPLICATION
+
+    def transformData(self, data):
+        """
+        Data can be transformed before sending to client.
+        Currently, the only transformation type implemented is 'nested'.
+        :param data:
+        :return:
+        """
+        transform = self.options['--transform']
+        if transform:
+            if transform == "nested":
+                return self.transformNestedData(data)
+            else:
+                raise RuntimeError('Unsupported transform type')
+        else:
+            return data
+
+    def transformNestedData(self, data):
+        """
+        If subclass supports 'nested' transformation then it needs to implement
+        this method and it can use and override provided helper methods.
+        By default the data is returned unchanged.
+
+        :param data:
+        :return:
+        """
+        return data
+
+    def nestedNodes(self, nodes):
+        """
+        Helper method to transform nodes object.
+        Subclass can override this if the default behaviour does not apply.
+
+        :param nodes:
+        :return:
+        """
+        if isinstance(nodes, dict):
+            nodesArray = []
+            for key in nodes:
+                n = nodes[key]
+                n['node'] = key
+                nodesArray.append(n)
+            return nodesArray
+        return nodes
+
+    def nestedNodesShardsArray(self, nodes):
+        """
+        Helper method to transform nodes shards array.
+        Subclass can override this if the default behaviour does not apply.
+
+        :param nodes:
+        :return:
+        """
+        if isinstance(nodes, dict):
+            shardsArray = []
+            for node in nodes:
+                if isinstance(nodes[node], list):
+                    for shard in nodes[node]:
+                        # shard['node'] = node
+                        # node value ^^ is already there in the dict
+                        shardsArray.append(shard)
+                else:
+                    raise RuntimeError('shards not in expected format')
+        else:
+            raise RuntimeError('shards not in expected format')
+        return shardsArray
+
+    def nestedIndices(self, indices):
+        """
+        Helper method to transform indices object.
+        Subclass can override this if the default behaviour does not apply.
+
+        :param indices:
+        :return:
+        """
+        if isinstance(indices, dict):
+            indicesArray = []
+            for key in indices:
+                i = indices[key]
+                i['index'] = key
+                indicesArray.append(i)
+            return indicesArray
+        else:
+            return indices
+
+    def nestedShards(self, shards):
+        """
+        Helper method to transform shards object.
+        Subclass can override this if the default behaviour does not apply.
+
+        :param shards:
+        :return:
+        """
+        if isinstance(shards, dict):
+            shardsArray = []
+            for key in shards:
+                s = shards[key]
+                # convert shard id to number (this is how other admin REST APIs represent it)
+                s['shard'] = int(key)
+                shardsArray.append(s)
+            return shardsArray
+        else:
+            return shards
+
+    def nestedShardsArray(self, shards):
+        """
+        Helper method to transform shards array.
+        This is useful in case REST API returns shards data in an array.
+
+        :param shards:
+        :return:
+        """
+        shardsArray = []
+        if isinstance(shards, dict):
+            for key in shards:
+                if isinstance(shards[key], list):
+                    for shard in shards[key]:
+                        shard['shard'] = int(key)
+                        shardsArray.append(shard)
+                else:
+                    raise RuntimeError('shards not in expected format')
+        else:
+            raise RuntimeError('shards not in expected format')
+        return shardsArray
+
+    def nestedIndicesAndShards(self, indices):
+        """
+        Helper method to transform indices and shards.
+        This method is designed for cases where index contains 'shards' key as the top level field.
+
+        :param indices:
+        :return:
+        """
+        indices = self.nestedIndices(indices)
+        for index in indices:
+            if isinstance(index, dict):
+                if 'shards' in index:
+                    index['shards'] = self.nestedShards(index['shards'])
+        return indices
 
     def check_filter_path(self, args):
         if self.options['--filter_path'] and self.options["--filter_path"] is not None and len(self.options["--filter_path"]) > 0:

--- a/watches/commands/cluster_health.py
+++ b/watches/commands/cluster_health.py
@@ -16,3 +16,8 @@ class ClusterHealth(Base):
         self.check_filter_path(args)
         return self.es.cluster.health(**args)
 
+    def transformNestedData(self, data):
+        if 'indices' in data:
+            data['indices'] = self.nestedIndicesAndShards(data['indices'])
+        return data
+

--- a/watches/commands/cluster_state.py
+++ b/watches/commands/cluster_state.py
@@ -16,3 +16,30 @@ class ClusterState(Base):
         self.check_filter_path(args)
         return self.es.cluster.state(**args)
 
+    def transformNestedData(self, data):
+
+        # for now skipping 'blocks' field
+
+        if 'metadata' in data:
+            metadata = data['metadata']
+            if 'indices' in metadata:
+                metadata['indices'] = self.nestedIndices(metadata['indices'])
+
+        if 'nodes' in data:
+            data['nodes'] = self.nestedNodes(data['nodes'])
+
+        # routing_table.indices
+        if 'routing_table' in data:
+            if 'indices' in data['routing_table']:
+                data['routing_table']['indices'] = self.nestedIndicesAndShards(data['routing_table']['indices'])
+
+        # routing_nodes.nodes
+        if 'routing_nodes' in data:
+            if 'nodes' in data['routing_nodes']:
+                data['routing_nodes']['nodes'] = self.nestedNodesShardsArray(data['routing_nodes']['nodes'])
+
+        return data
+
+    def nestedShards(self, shards):
+        return self.nestedShardsArray(shards)
+

--- a/watches/commands/indices_stats.py
+++ b/watches/commands/indices_stats.py
@@ -14,3 +14,11 @@ class IndicesStats(Base):
         }
         self.check_filter_path(args)
         return self.es.indices.stats(**args)
+
+    def transformNestedData(self, data):
+        if 'indices' in data:
+            data['indices'] = self.nestedIndicesAndShards(data['indices'])
+        return data
+
+    def nestedShards(self, shards):
+        return self.nestedShardsArray(shards)

--- a/watches/commands/nodes_info.py
+++ b/watches/commands/nodes_info.py
@@ -14,3 +14,8 @@ class NodesInfo(Base):
         }
         self.check_filter_path(args)
         return self.es.nodes.info(**args)
+
+    def transformNestedData(self, data):
+        if 'nodes' in data:
+            data['nodes'] = self.nestedNodes(data['nodes'])
+        return data

--- a/watches/commands/nodes_stats.py
+++ b/watches/commands/nodes_stats.py
@@ -13,3 +13,8 @@ class NodesStats(Base):
         }
         self.check_filter_path(args)
         return self.es.nodes.stats(**args)
+
+    def transformNestedData(self, data):
+        if 'nodes' in data:
+            data['nodes'] = self.nestedNodes(data['nodes'])
+        return data


### PR DESCRIPTION
Most commands accept `--transform=nested` option. It transforms JSON response to nested data (this means the JSON does not contain data as a JSON keys).

Make tests pass on clusters with more than one node.

Closes #24 